### PR TITLE
バグ修正 / バインディングエラーを回避するためのコードを追加

### DIFF
--- a/MemoSoft/MainWindow.xaml
+++ b/MemoSoft/MainWindow.xaml
@@ -51,6 +51,13 @@
                 <ListBox HorizontalContentAlignment="Stretch"
                          ItemsSource="{Binding PostgreSQLDatabaseHelper.Comments}">
 
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListBoxItem}" >
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            <Setter Property="VerticalContentAlignment" Value="Center"/>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                    
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Border BorderBrush="#bbDDFF"


### PR DESCRIPTION
あまり詳しくは原因がわからなかった。どうもリストを入れ替えている際、何かまずいことが起こっているらしい。

とりあえずエラーは回避できたが、一部のスタイルが適用されなくなってしまった。
エラーの方が気持ち悪いのでとりあえずそっちを優先的に消す。
今回、リストボックスを使用しているが、いっそ使い慣れているリストビューに入れ替えて作り直したほうがいいかも？

close #5
